### PR TITLE
SSM経由でAMIID自動取得

### DIFF
--- a/cicd-target-template/cfn_template_file_example.yaml
+++ b/cicd-target-template/cfn_template_file_example.yaml
@@ -6,9 +6,9 @@ Parameters:
     Type: AWS::EC2::Subnet::Id
     Default: TARGETSUBNETID
   ImageId:
-    Description: Amazon Linux 2 AMI ap-northeast
-    Type: AWS::EC2::Image::Id
-    Default: ami-00d101850e971728d
+    Description: Latest Amazon Linux 2 AMI
+    Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
+    Default: /aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2
 
 Resources:
   EC2Instance:


### PR DESCRIPTION
Closes #4 

CloudFormationではマルチリージョンでAMIIDを取り扱う際に以下の方法がある。
- Mappingを使用してAMIIDとリージョンを列挙する方法
- SSMを経由して最新のAMIIDを取得する方法 [参考](https://aws.amazon.com/jp/blogs/compute/query-for-the-latest-amazon-linux-ami-ids-using-aws-systems-manager-parameter-store/) 
  - AmazonLinux2等限られたAMIのみ可能

後者を採用し実装。